### PR TITLE
Checking for spaces in postal code can be turned off

### DIFF
--- a/lib/Sirprize/PostalCodeValidator/Validator.php
+++ b/lib/Sirprize/PostalCodeValidator/Validator.php
@@ -304,7 +304,7 @@ class Validator
         'ZW' => array(),                            # ZIMBABWE
     );
 
-    public function isValid($countryCode, $postalCode,$ignoreSpaces=false)
+    public function isValid($countryCode, $postalCode, $ignoreSpaces=false)
     {
         if(!isset($this->formats[$countryCode]))
         {
@@ -314,7 +314,7 @@ class Validator
         foreach($this->formats[$countryCode] as $format)
         {
             #echo $postalCode . ' - ' . $this->getFormatPattern($format)."\n";
-            if(preg_match($this->getFormatPattern($format,$ignoreSpaces), $postalCode))
+            if(preg_match($this->getFormatPattern($format, $ignoreSpaces), $postalCode))
             {
                 return true;
             }
@@ -343,7 +343,7 @@ class Validator
         return (isset($this->formats[$countryCode]));
     }
     
-    protected function getFormatPattern($format,$ignoreSpaces=false)
+    protected function getFormatPattern($format, $ignoreSpaces=false)
     {
         $pattern = str_replace('#', '\d', $format);
         $pattern = str_replace('@', '[a-zA-Z]', $pattern);

--- a/tests/Sirprize/Tests/PostalCodeValidator/ValidatorTest.php
+++ b/tests/Sirprize/Tests/PostalCodeValidator/ValidatorTest.php
@@ -100,6 +100,6 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $validator = new Validator();
         $this->assertTrue($validator->isValid('CZ', '602 00'));
         $this->assertFalse($validator->isValid('CZ', '60200'));
-        $this->assertTrue($validator->isValid('CZ', '60200',true));
+        $this->assertTrue($validator->isValid('CZ', '60200', true));
     }
 }


### PR DESCRIPTION
I'd like to be able to check postal code, but without spaces being strictly checked.

I implemented optional parameter to isValid() which makes space in postal code formatting optional.
