### PR TITLE
Fix Dutch postal codes (#### is not a valid postal code)

### DIFF
--- a/lib/Sirprize/PostalCodeValidator/Validator.php
+++ b/lib/Sirprize/PostalCodeValidator/Validator.php
@@ -206,7 +206,7 @@ class Validator
         'NF' => array(),                            # NORFOLK ISLAND
         'NG' => array('######'),                    # NIGERIA
         'NI' => array('###-###-#'),                 # NICARAGUA
-        'NL' => array('#### @@', '####', '####@@'), # NETHERLANDS
+        'NL' => array('#### @@', '####@@'),         # NETHERLANDS
         'NO' => array('####'),                      # NORWAY
         'NP' => array('#####'),                     # NEPAL
         'NR' => array(),                            # NAURU


### PR DESCRIPTION
\#### is not a valid Dutch postal code.
See, for example: http://formvalidation.io/validators/zipCode/