### PR TITLE
Add missing South Korea post code format

### DIFF
--- a/lib/Sirprize/PostalCodeValidator/Validator.php
+++ b/lib/Sirprize/PostalCodeValidator/Validator.php
@@ -159,7 +159,7 @@ class Validator
         'KN' => array(),                            # SAINT KITTS AND NEVIS
         'KO' => array(),                            # Kosovo
         'KP' => array(),                            # NORTH KOREA
-        'KR' => array('###-###'),                   # SOUTH KOREA
+        'KR' => array('###-###', '#####'),          # SOUTH KOREA
         'KW' => array(),                            # KUWAIT
         'KY' => array(),                            # CAYMAN ISLANDS
         'KZ' => array('######'),                    # KAZAKHSTAN


### PR DESCRIPTION
There is missing South Korea post code format. Ref https://en.wikipedia.org/wiki/Addresses_in_South_Korea#Postal_Address