### PR TITLE
Fixed an issue with the japanese postal code formats

### DIFF
--- a/lib/Sirprize/PostalCodeValidator/Validator.php
+++ b/lib/Sirprize/PostalCodeValidator/Validator.php
@@ -149,7 +149,7 @@ class Validator
         'JE' => array('@@# #@@'),                   # Jersey
         'JM' => array(),                            # JAMAICA
         'JO' => array(),                            # JORDAN
-        'JP' => array('###-####', '#######', '###'),# JAPAN
+        'JP' => array('###-####', '###'),           # JAPAN
 
         'KE' => array('#####'),                     # KENYA
         'KG' => array('######'),                    # KYRGYZSTAN

--- a/tests/Sirprize/Tests/PostalCodeValidator/ValidatorTest.php
+++ b/tests/Sirprize/Tests/PostalCodeValidator/ValidatorTest.php
@@ -51,6 +51,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
     {
         $validator = new Validator();
         $this->assertTrue($validator->isValid('JP', '155-0031'));
+        $this->assertFalse($validator->isValid('JP', '1550031'));
     }
     
     public function testUsCode()


### PR DESCRIPTION
Hi Christian,

We are using your library to check the correct formatting of postal codes before using the DHL Webservice to create shipping labels.

We noticed that the Japan format `#######` is incorrect according to the postal code format PDF and also according to the Webservice that rejects any postal code using the 7 digits format with the following message:

```
Invalid postal code of a consignee. Please provide a valid postal code for a consignee and resubmit.; 
```

This pull request corrects that issue. A test for this specific situation was also added.

Thank you,
Ricardo Velhote