### PR TITLE
Update code standards to PHP 7.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 vendor/
 composer.phar
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
         "psr-4": { "Sirprize\\PostalCodeValidator\\Tests\\": "tests/" }
     },
     "require": {
-        "php": ">=5.3.2"
+        "php": ">=7.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.36 || ^5.5 || ^6.5"
+        "phpunit/phpunit": "^8.0"
     },
     "extra": {
         "branch-alias": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e47ef963aa167cd99f7c1cb2391f96a8",
+    "content-hash": "cd07418d737a7caff4dd7a427a061a18",
     "packages": [],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "a2c590166b2133a4633738648b6b064edae0814a"
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/a2c590166b2133a4633738648b6b064edae0814a",
-                "reference": "a2c590166b2133a4633738648b6b064edae0814a",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/ae466f726242e637cebdd526a7d991b9433bacf1",
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1",
                 "shasum": ""
             },
             "require": {
@@ -61,20 +61,20 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2019-03-17T17:37:11+00:00"
+            "time": "2019-10-21T16:45:58+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.9.1",
+            "version": "1.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72"
+                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
-                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/b2c28789e80a97badd14145fda39b545d83ca3ef",
+                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef",
                 "shasum": ""
             },
             "require": {
@@ -109,26 +109,26 @@
                 "object",
                 "object graph"
             ],
-            "time": "2019-04-07T13:18:21+00:00"
+            "time": "2020-01-17T21:11:47+00:00"
         },
         {
             "name": "phar-io/manifest",
-            "version": "1.0.1",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-phar": "*",
-                "phar-io/version": "^1.0.1",
+                "phar-io/version": "^2.0",
                 "php": "^5.6 || ^7.0"
             },
             "type": "library",
@@ -164,20 +164,20 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2017-03-05T18:14:27+00:00"
+            "time": "2018-07-08T19:23:20+00:00"
         },
         {
             "name": "phar-io/version",
-            "version": "1.0.1",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
                 "shasum": ""
             },
             "require": {
@@ -211,39 +211,37 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "time": "2017-03-05T17:38:23+00:00"
+            "time": "2018-07-08T19:19:57+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
-            "version": "1.0.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.6"
+                "phpunit/phpunit": "~6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -265,44 +263,42 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2017-09-11T18:02:19+00:00"
+            "time": "2018-08-07T13:53:10+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.1",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c"
+                "reference": "a48807183a4b819072f26e347bbd0b5199a9d15f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
-                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/a48807183a4b819072f26e347bbd0b5199a9d15f",
+                "reference": "a48807183a4b819072f26e347bbd0b5199a9d15f",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0.0",
-                "phpdocumentor/type-resolver": "^0.4.0",
-                "webmozart/assert": "^1.0"
+                "ext-filter": "^7.1",
+                "php": "^7.2",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpdocumentor/type-resolver": "^1.0",
+                "webmozart/assert": "^1"
             },
             "require-dev": {
-                "doctrine/instantiator": "~1.0.5",
-                "mockery/mockery": "^1.0",
-                "phpunit/phpunit": "^6.4"
+                "doctrine/instantiator": "^1",
+                "mockery/mockery": "^1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.x-dev"
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -313,44 +309,47 @@
                 {
                     "name": "Mike van Riel",
                     "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "account@ijaap.nl"
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2019-04-30T17:48:53+00:00"
+            "time": "2020-02-09T09:16:15+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.4.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
+                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
+                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0",
-                "phpdocumentor/reflection-common": "^1.0"
+                "php": "^7.1",
+                "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^5.2||^4.8.24"
+                "ext-tokenizer": "^7.1",
+                "mockery/mockery": "~1",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -363,37 +362,38 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2017-07-14T14:27:02+00:00"
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "time": "2019-08-22T18:11:29+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.8.1",
+            "version": "v1.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76"
+                "reference": "b4400efc9d206e83138e2bb97ed7f5b14b831cd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
-                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/b4400efc9d206e83138e2bb97ed7f5b14b831cd9",
+                "reference": "b4400efc9d206e83138e2bb97ed7f5b14b831cd9",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
-                "sebastian/comparator": "^1.1|^2.0|^3.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
+                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.5|^3.2",
+                "phpspec/phpspec": "^2.5 || ^3.2",
                 "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8.x-dev"
+                    "dev-master": "1.10.x-dev"
                 }
             },
             "autoload": {
@@ -426,44 +426,44 @@
                 "spy",
                 "stub"
             ],
-            "time": "2019-06-13T12:50:23+00:00"
+            "time": "2020-01-20T15:57:02+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.3.2",
+            "version": "7.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "c89677919c5dd6d3b3852f230a663118762218ac"
+                "reference": "f1884187926fbb755a9aaf0b3836ad3165b478bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c89677919c5dd6d3b3852f230a663118762218ac",
-                "reference": "c89677919c5dd6d3b3852f230a663118762218ac",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f1884187926fbb755a9aaf0b3836ad3165b478bf",
+                "reference": "f1884187926fbb755a9aaf0b3836ad3165b478bf",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.0",
-                "phpunit/php-file-iterator": "^1.4.2",
+                "php": "^7.2",
+                "phpunit/php-file-iterator": "^2.0.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^2.0.1",
+                "phpunit/php-token-stream": "^3.1.1",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.0",
+                "sebastian/environment": "^4.2.2",
                 "sebastian/version": "^2.0.1",
-                "theseer/tokenizer": "^1.1"
+                "theseer/tokenizer": "^1.1.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^8.2.2"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.5"
+                "ext-xdebug": "^2.7.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.3.x-dev"
+                    "dev-master": "7.0-dev"
                 }
             },
             "autoload": {
@@ -489,29 +489,32 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-04-06T15:36:58+00:00"
+            "time": "2019-11-20T13:55:58+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.5",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
+                "reference": "050bedf145a257b1ff02746c31894800e5122946"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/050bedf145a257b1ff02746c31894800e5122946",
+                "reference": "050bedf145a257b1ff02746c31894800e5122946",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -526,7 +529,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -536,7 +539,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2017-11-27T13:52:08+00:00"
+            "time": "2018-09-13T20:33:42+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -581,28 +584,28 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.9",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/1038454804406b0b5f5f520358e78c1c2f71501e",
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.1-dev"
                 }
             },
             "autoload": {
@@ -617,7 +620,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -626,33 +629,33 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26T11:10:40+00:00"
+            "time": "2019-06-07T04:22:29+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "2.0.2",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "791198a2c6254db10131eecfe8c06670700904db"
+                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
-                "reference": "791198a2c6254db10131eecfe8c06670700904db",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/995192df77f63a59e47f025390d2d1fdf8f425ff",
+                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2.4"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -675,57 +678,56 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-11-27T05:48:46+00:00"
+            "time": "2019-09-17T06:23:10+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.5.14",
+            "version": "8.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7"
+                "reference": "018b6ac3c8ab20916db85fa91bf6465acb64d1e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/bac23fe7ff13dbdb461481f706f0e9fe746334b7",
-                "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/018b6ac3c8ab20916db85fa91bf6465acb64d1e0",
+                "reference": "018b6ac3c8ab20916db85fa91bf6465acb64d1e0",
                 "shasum": ""
             },
             "require": {
+                "doctrine/instantiator": "^1.2.0",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.6.1",
-                "phar-io/manifest": "^1.0.1",
-                "phar-io/version": "^1.0",
-                "php": "^7.0",
-                "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^5.3",
-                "phpunit/php-file-iterator": "^1.4.3",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.9.1",
+                "phar-io/manifest": "^1.0.3",
+                "phar-io/version": "^2.0.1",
+                "php": "^7.2",
+                "phpspec/prophecy": "^1.8.1",
+                "phpunit/php-code-coverage": "^7.0.7",
+                "phpunit/php-file-iterator": "^2.0.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^1.0.9",
-                "phpunit/phpunit-mock-objects": "^5.0.9",
-                "sebastian/comparator": "^2.1",
-                "sebastian/diff": "^2.0",
-                "sebastian/environment": "^3.1",
-                "sebastian/exporter": "^3.1",
-                "sebastian/global-state": "^2.0",
+                "phpunit/php-timer": "^2.1.2",
+                "sebastian/comparator": "^3.0.2",
+                "sebastian/diff": "^3.0.2",
+                "sebastian/environment": "^4.2.2",
+                "sebastian/exporter": "^3.1.1",
+                "sebastian/global-state": "^3.0.0",
                 "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^1.0",
+                "sebastian/resource-operations": "^2.0.1",
+                "sebastian/type": "^1.1.3",
                 "sebastian/version": "^2.0.1"
-            },
-            "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2",
-                "phpunit/dbunit": "<3.0"
             },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
+                "ext-soap": "*",
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "^1.1"
+                "phpunit/php-invoker": "^2.0.0"
             },
             "bin": [
                 "phpunit"
@@ -733,67 +735,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.5.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "The PHP Unit Testing framework.",
-            "homepage": "https://phpunit.de/",
-            "keywords": [
-                "phpunit",
-                "testing",
-                "xunit"
-            ],
-            "time": "2019-02-01T05:22:47+00:00"
-        },
-        {
-            "name": "phpunit/phpunit-mock-objects",
-            "version": "5.0.10",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/cd1cf05c553ecfec36b170070573e540b67d3f1f",
-                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.0.5",
-                "php": "^7.0",
-                "phpunit/php-text-template": "^1.2.1",
-                "sebastian/exporter": "^3.1"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<6.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.5.11"
-            },
-            "suggest": {
-                "ext-soap": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0.x-dev"
+                    "dev-master": "8.5-dev"
                 }
             },
             "autoload": {
@@ -812,14 +754,14 @@
                     "role": "lead"
                 }
             ],
-            "description": "Mock Object library for PHPUnit",
-            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
             "keywords": [
-                "mock",
+                "phpunit",
+                "testing",
                 "xunit"
             ],
-            "abandoned": true,
-            "time": "2018-08-09T05:50:03+00:00"
+            "time": "2020-01-08T08:49:49+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -868,30 +810,30 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "2.1.3",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
-                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/diff": "^2.0 || ^3.0",
+                "php": "^7.1",
+                "sebastian/diff": "^3.0",
                 "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.4"
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -928,32 +870,33 @@
                 "compare",
                 "equality"
             ],
-            "time": "2018-02-01T13:46:46+00:00"
+            "time": "2018-07-12T15:12:46+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "2.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2"
+                "phpunit/phpunit": "^7.5 || ^8.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -978,34 +921,40 @@
             "description": "Diff implementation",
             "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
-                "diff"
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
             ],
-            "time": "2017-08-03T08:09:46+00:00"
+            "time": "2019-02-04T06:01:07+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "3.1.0",
+            "version": "4.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
+                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
+                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.1"
+                "phpunit/phpunit": "^7.5"
+            },
+            "suggest": {
+                "ext-posix": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -1030,20 +979,20 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2017-07-01T08:51:00+00:00"
+            "time": "2019-11-20T08:46:58+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.0",
+            "version": "3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937"
+                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/234199f4528de6d12aaa58b612e98f7d36adb937",
-                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/68609e1261d215ea5b21b7987539cbfbe156ec3e",
+                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e",
                 "shasum": ""
             },
             "require": {
@@ -1071,6 +1020,10 @@
             ],
             "authors": [
                 {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
                 },
@@ -1079,16 +1032,12 @@
                     "email": "github@wallbash.com"
                 },
                 {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
                     "name": "Adam Harvey",
                     "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
@@ -1097,27 +1046,30 @@
                 "export",
                 "exporter"
             ],
-            "time": "2017-04-03T13:19:02+00:00"
+            "time": "2019-09-14T09:02:43+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "2.0.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+                "reference": "edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4",
+                "reference": "edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.2",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "ext-dom": "*",
+                "phpunit/phpunit": "^8.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -1125,7 +1077,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1148,7 +1100,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2017-04-27T15:39:26+00:00"
+            "time": "2019-02-01T05:30:01+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -1297,25 +1249,25 @@
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "1.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.0"
+                "php": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1335,7 +1287,53 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28T20:34:47+00:00"
+            "time": "2018-10-04T04:07:39+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "3aaaa15fa71d27650d62a948be022fe3b48541a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/3aaaa15fa71d27650d62a948be022fe3b48541a3",
+                "reference": "3aaaa15fa71d27650d62a948be022fe3b48541a3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "time": "2019-07-02T08:10:15+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1382,16 +1380,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.11.0",
+            "version": "v1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "82ebae02209c21113908c229e9883c419720738a"
+                "reference": "fbdeaec0df06cf3d51c93de80c7eb76e271f5a38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/82ebae02209c21113908c229e9883c419720738a",
-                "reference": "82ebae02209c21113908c229e9883c419720738a",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/fbdeaec0df06cf3d51c93de80c7eb76e271f5a38",
+                "reference": "fbdeaec0df06cf3d51c93de80c7eb76e271f5a38",
                 "shasum": ""
             },
             "require": {
@@ -1403,7 +1401,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11-dev"
+                    "dev-master": "1.14-dev"
                 }
             },
             "autoload": {
@@ -1420,12 +1418,12 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                },
-                {
                     "name": "Gert de Pagter",
                     "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -1436,7 +1434,7 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-02-06T07:57:58+00:00"
+            "time": "2020-01-13T11:15:53+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -1480,32 +1478,29 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.4.0",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9"
+                "reference": "573381c0a64f155a0d9a23f4b0c797194805b925"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/83e253c8e0be5b0257b881e1827274667c5c17a9",
-                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/573381c0a64f155a0d9a23f4b0c797194805b925",
+                "reference": "573381c0a64f155a0d9a23f4b0c797194805b925",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.3 || ^7.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
+            "conflict": {
+                "vimeo/psalm": "<3.6.0"
+            },
             "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -1527,7 +1522,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-12-25T11:19:39+00:00"
+            "time": "2019-11-24T13:36:37+00:00"
         }
     ],
     "aliases": [],
@@ -1536,7 +1531,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.2"
+        "php": ">=7.2"
     },
     "platform-dev": []
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="./vendor/autoload.php"
 >
     <testsuites>

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -23,287 +23,287 @@ class Validator
      *
      * @var array
      */
-    protected $formats = array(
-        'AC' => array(),                            # Ascension
-        'AD' => array('AD###', '#####'),            # ANDORRA
-        'AE' => array(),                            # UNITED ARAB EMIRATES
-        'AF' => array('####'),                      # AFGHANISTAN
-        'AG' => array(),                            # ANTIGUA AND BARBUDA
-        'AI' => array('AI-2640'),                   # ANGUILLA
-        'AL' => array('####'),                      # ALBANIA
-        'AM' => array('####'),                      # ARMENIA
-        'AN' => array(),                            # NETHERLANDS ANTILLES
-        'AO' => array(),                            # ANGOLA
-        'AQ' => array('BIQQ 1ZZ'),                  # ANTARCTICA
-        'AR' => array('####', '@####@@@'),          # ARGENTINA
-        'AS' => array('#####', '#####-####'),       # AMERICAN SAMOA
-        'AT' => array('####'),                      # AUSTRIA
-        'AU' => array('####'),                      # AUSTRALIA
-        'AW' => array(),                            # ARUBA
-        'AX' => array('#####', 'AX-#####'),         # Åland
-        'AZ' => array('AZ ####'),                   # AZERBAIJAN
+    protected $formats = [
+        'AC' => [],                            # ASCENSION
+        'AD' => ['AD###', '#####'],            # ANDORRA
+        'AE' => [],                            # UNITED ARAB EMIRATES
+        'AF' => ['####'],                      # AFGHANISTAN
+        'AG' => [],                            # ANTIGUA AND BARBUDA
+        'AI' => ['AI-2640'],                   # ANGUILLA
+        'AL' => ['####'],                      # ALBANIA
+        'AM' => ['####'],                      # ARMENIA
+        'AN' => [],                            # NETHERLANDS ANTILLES
+        'AO' => [],                            # ANGOLA
+        'AQ' => ['BIQQ 1ZZ'],                  # ANTARCTICA
+        'AR' => ['####', '@####@@@'],          # ARGENTINA
+        'AS' => ['#####', '#####-####'],       # AMERICAN SAMOA
+        'AT' => ['####'],                      # AUSTRIA
+        'AU' => ['####'],                      # AUSTRALIA
+        'AW' => [],                            # ARUBA
+        'AX' => ['#####', 'AX-#####'],         # ÅLAND
+        'AZ' => ['AZ ####'],                   # AZERBAIJAN
 
-        'BA' => array('#####'),                     # BOSNIA AND HERZEGOWINA
-        'BB' => array('BB#####'),                   # BARBADOS
-        'BD' => array('####'),                      # BANGLADESH
-        'BE' => array('####'),                      # BELGIUM
-        'BF' => array(),                            # BURKINA FASO
-        'BG' => array('####'),                      # BULGARIA
-        'BH' => array('###', '####'),               # BAHRAIN
-        'BI' => array(),                            # BURUNDI
-        'BJ' => array(),                            # BENIN
-        'BL' => array('#####'),                     # Sankt Bartholomäus
-        'BM' => array('@@ ##', '@@ @@'),            # BERMUDA
-        'BN' => array('@@####'),                    # BRUNEI DARUSSALAM
-        'BO' => array(),                            # BOLIVIA
-        'BQ' => array(),                            # Karibische Niederlande
-        'BR' => array('#####-###', '#####'),        # BRAZIL
-        'BS' => array(),                            # BAHAMAS
-        'BT' => array('#####'),                     # BHUTAN
-        'BV' => array(),                            # BOUVET ISLAND
-        'BW' => array(),                            # BOTSWANA
-        'BY' => array('######'),                    # BELARUS
-        'BZ' => array(),                            # BELIZE
+        'BA' => ['#####'],                     # BOSNIA AND HERZEGOWINA
+        'BB' => ['BB#####'],                   # BARBADOS
+        'BD' => ['####'],                      # BANGLADESH
+        'BE' => ['####'],                      # BELGIUM
+        'BF' => [],                            # BURKINA FASO
+        'BG' => ['####'],                      # BULGARIA
+        'BH' => ['###', '####'],               # BAHRAIN
+        'BI' => [],                            # BURUNDI
+        'BJ' => [],                            # BENIN
+        'BL' => ['#####'],                     # SANKT BARTHOLOMÄUS
+        'BM' => ['@@ ##', '@@ @@'],            # BERMUDA
+        'BN' => ['@@####'],                    # BRUNEI DARUSSALAM
+        'BO' => [],                            # BOLIVIA
+        'BQ' => [],                            # BONAIRE, SAINT EUSTATIUS, SABA
+        'BR' => ['#####-###', '#####'],        # BRAZIL
+        'BS' => [],                            # BAHAMAS
+        'BT' => ['#####'],                     # BHUTAN
+        'BV' => [],                            # BOUVET ISLAND
+        'BW' => [],                            # BOTSWANA
+        'BY' => ['######'],                    # BELARUS
+        'BZ' => [],                            # BELIZE
 
-        'CA' => array('@#@ #@#'),                   # CANADA
-        'CC' => array('####'),                      # COCOS (KEELING) ISLANDS
-        'CD' => array(),                            # CONGO, Democratic Republic of (was Zaire)
-        'CF' => array(),                            # CENTRAL AFRICAN REPUBLIC
-        'CG' => array(),                            # CONGO, People's Republic of
-        'CH' => array('####'),                      # SWITZERLAND
-        'CI' => array(),                            # COTE D'IVOIRE
-        'CK' => array(),                            # COOK ISLANDS
-        'CL' => array('#######', '###-####'),       # CHILE
-        'CM' => array(),                            # CAMEROON
-        'CN' => array('######'),                    # CHINA
-        'CO' => array('######'),                    # COLOMBIA
-        'CR' => array('#####', '#####-####'),       # COSTA RICA
-        'CU' => array('#####'),                     # CUBA
-        'CV' => array('####'),                      # CAPE VERDE
-        'CW' => array(),                            # Curaçao
-        'CX' => array('####'),                      # CHRISTMAS ISLAND
-        'CY' => array('####'),                      # Cyprus
-        'CZ' => array('### ##'),                    # Czech Republic
+        'CA' => ['@#@ #@#'],                   # CANADA
+        'CC' => ['####'],                      # COCOS (KEELING) ISLANDS
+        'CD' => [],                            # CONGO, Democratic Republic of (was Zaire)
+        'CF' => [],                            # CENTRAL AFRICAN REPUBLIC
+        'CG' => [],                            # CONGO, People's Republic of
+        'CH' => ['####'],                      # SWITZERLAND
+        'CI' => [],                            # COTE D'IVOIRE
+        'CK' => [],                            # COOK ISLANDS
+        'CL' => ['#######', '###-####'],       # CHILE
+        'CM' => [],                            # CAMEROON
+        'CN' => ['######'],                    # CHINA
+        'CO' => ['######'],                    # COLOMBIA
+        'CR' => ['#####', '#####-####'],       # COSTA RICA
+        'CU' => ['#####'],                     # CUBA
+        'CV' => ['####'],                      # CAPE VERDE
+        'CW' => [],                            # CURACAO
+        'CX' => ['####'],                      # CHRISTMAS ISLAND
+        'CY' => ['####'],                      # CYPRUS
+        'CZ' => ['### ##'],                    # CZECH REPUBLICS
 
-        'DE' => array('#####'),                     # GERMANY
-        'DJ' => array(),                            # DJIBOUTI
-        'DK' => array('####'),                      # DENMARK
-        'DM' => array(),                            # DOMINICA
-        'DO' => array('#####'),                     # DOMINICAN REPUBLIC
-        'DZ' => array('#####'),                     # ALGERIA
+        'DE' => ['#####'],                     # GERMANY
+        'DJ' => [],                            # DJIBOUTI
+        'DK' => ['####'],                      # DENMARK
+        'DM' => [],                            # DOMINICA
+        'DO' => ['#####'],                     # DOMINICAN REPUBLIC
+        'DZ' => ['#####'],                     # ALGERIA
 
-        'EC' => array('######'),                    # ECUADOR
-        'EE' => array('#####'),                     # ESTONIA
-        'EG' => array('#####'),                     # EGYPT
-        'EH' => array(),                            # WESTERN SAHARA
-        'ER' => array(),                            # ERITREA
-        'ES' => array('#####'),                     # SPAIN
-        'ET' => array('####'),                      # ETHIOPIA
+        'EC' => ['######'],                    # ECUADOR
+        'EE' => ['#####'],                     # ESTONIA
+        'EG' => ['#####'],                     # EGYPT
+        'EH' => [],                            # WESTERN SAHARA
+        'ER' => [],                            # ERITREA
+        'ES' => ['#####'],                     # SPAIN
+        'ET' => ['####'],                      # ETHIOPIA
 
-        'FI' => array('#####'),                     # FINLAND
-        'FJ' => array(),                            # FIJI
-        'FK' => array('FIQQ 1ZZ'),                  # FALKLAND ISLANDS (MALVINAS)
-        'FM' => array('#####', '#####-####'),       # MICRONESIA
-        'FO' => array('###'),                       # FAROE ISLANDS
-        'FR' => array('#####'),                     # FRANCE
-        'FX' => array(),                            # FRANCE, METROPOLITAN
+        'FI' => ['#####'],                     # FINLAND
+        'FJ' => [],                            # FIJI
+        'FK' => ['FIQQ 1ZZ'],                  # FALKLAND ISLANDS (MALVINAS)
+        'FM' => ['#####', '#####-####'],       # MICRONESIA
+        'FO' => ['###'],                       # FAROE ISLANDS
+        'FR' => ['#####'],                     # FRANCE
+        'FX' => [],                            # FRANCE, METROPOLITAN
 
-        'GA' => array(),                            # GABON
-        'GB' => array('@@## #@@', '@#@ #@@', '@@# #@@', '@@#@ #@@', '@## #@@', '@# #@@'), # UK
-        'GD' => array(),                            # GRENADA
-        'GE' => array('####'),                      # GEORGIA
-        'GF' => array('973##'),                     # FRENCH GUIANA
-        'GG' => array('GY# #@@', 'GY## #@@'),       # Guernsey
-        'GH' => array(),                            # GHANA
-        'GI' => array('GX11 1AA'),                  # GIBRALTAR
-        'GL' => array('####'),                      # GREENLAND
-        'GM' => array(),                            # GAMBIA
-        'GN' => array('###'),                       # GUINEA
-        'GP' => array('971##'),                     # GUADELOUPE
-        'GQ' => array(),                            # EQUATORIAL GUINEA
-        'GR' => array('### ##'),                    # GREECE
-        'GS' => array('SIQQ 1ZZ'),                  # SOUTH GEORGIA AND THE SOUTH SANDWICH ISLANDS
-        'GT' => array('#####'),                     # GUATEMALA
-        'GU' => array('#####', '#####-####'),       # GUAM
-        'GW' => array('####'),                      # GUINEA-BISSAU
-        'GY' => array(),                            # GUYANA
+        'GA' => [],                            # GABON
+        'GB' => ['@@## #@@', '@#@ #@@', '@@# #@@', '@@#@ #@@', '@## #@@', '@# #@@'], # GREAT BRITAIN
+        'GD' => [],                            # GRENADA
+        'GE' => ['####'],                      # GEORGIA
+        'GF' => ['973##'],                     # FRENCH GUIANA
+        'GG' => ['GY# #@@', 'GY## #@@'],       # Guernsey
+        'GH' => [],                            # GHANA
+        'GI' => ['GX11 1AA'],                  # GIBRALTAR
+        'GL' => ['####'],                      # GREENLAND
+        'GM' => [],                            # GAMBIA
+        'GN' => ['###'],                       # GUINEA
+        'GP' => ['971##'],                     # GUADELOUPE
+        'GQ' => [],                            # EQUATORIAL GUINEA
+        'GR' => ['### ##'],                    # GREECE
+        'GS' => ['SIQQ 1ZZ'],                  # SOUTH GEORGIA AND THE SOUTH SANDWICH ISLANDS
+        'GT' => ['#####'],                     # GUATEMALA
+        'GU' => ['#####', '#####-####'],       # GUAM
+        'GW' => ['####'],                      # GUINEA-BISSAU
+        'GY' => [],                            # GUYANA
 
-        'HK' => array(),                            # HONG KONG
-        'HM' => array(),                            # HEARD AND MC DONALD ISLANDS
-        'HN' => array('@@####', '#####'),           # HONDURAS
-        'HR' => array('#####'),                     # CROATIA
-        'HT' => array('####'),                      # HAITI
-        'HU' => array('####'),                      # HUNGARY
+        'HK' => [],                            # HONG KONG
+        'HM' => [],                            # HEARD AND MC DONALD ISLANDS
+        'HN' => ['@@####', '#####'],           # HONDURAS
+        'HR' => ['#####'],                     # CROATIA
+        'HT' => ['####'],                      # HAITI
+        'HU' => ['####'],                      # HUNGARY
 
-        'IC' => array('#####'),                     # THE CANARY ISLANDS
-        'ID' => array('#####'),                     # INDONESIA
-        'IE' => array('@** ****'),                  # IRELAND
-        'IL' => array('#######'),                   # ISRAEL
-        'IM' => array('IM# #@@', 'IM## #@@'),       # Isle of Man
-        'IN' => array('######', '### ###'),         # INDIA
-        'IO' => array('BBND 1ZZ'),                  # BRITISH INDIAN OCEAN TERRITORY
-        'IQ' => array('#####'),                     # IRAQ
-        'IR' => array('##########', '#####-#####'), # IRAN
-        'IS' => array('###'),                       # ICELAND
-        'IT' => array('#####'),                     # ITALY
+        'IC' => ['#####'],                     # THE CANARY ISLANDS
+        'ID' => ['#####'],                     # INDONESIA
+        'IE' => ['@** ****'],                  # IRELAND
+        'IL' => ['#######'],                   # ISRAEL
+        'IM' => ['IM# #@@', 'IM## #@@'],       # Isle of Man
+        'IN' => ['######', '### ###'],         # INDIA
+        'IO' => ['BBND 1ZZ'],                  # BRITISH INDIAN OCEAN TERRITORY
+        'IQ' => ['#####'],                     # IRAQ
+        'IR' => ['##########', '#####-#####'], # IRAN
+        'IS' => ['###'],                       # ICELAND
+        'IT' => ['#####'],                     # ITALY
 
-        'JE' => array('JE# #@@', 'JE## #@@'),       # Jersey
-        'JM' => array('##'),                        # JAMAICA
-        'JO' => array('#####'),                     # JORDAN
-        'JP' => array('###-####', '###'),           # JAPAN
+        'JE' => ['JE# #@@', 'JE## #@@'],       # Jersey
+        'JM' => ['##'],                        # JAMAICA
+        'JO' => ['#####'],                     # JORDAN
+        'JP' => ['###-####', '###'],           # JAPAN
 
-        'KE' => array('#####'),                     # KENYA
-        'KG' => array('######'),                    # KYRGYZSTAN
-        'KH' => array('#####'),                     # CAMBODIA
-        'KI' => array(),                            # KIRIBATI
-        'KM' => array(),                            # COMOROS
-        'KN' => array(),                            # SAINT KITTS AND NEVIS
-        'KO' => array(),                            # Kosovo
-        'KP' => array(),                            # NORTH KOREA
-        'KR' => array('###-###', '#####'),          # SOUTH KOREA
-        'KW' => array('#####'),                     # KUWAIT
-        'KY' => array('KY#-####'),                  # CAYMAN ISLANDS
-        'KZ' => array('######'),                    # KAZAKHSTAN
+        'KE' => ['#####'],                     # KENYA
+        'KG' => ['######'],                    # KYRGYZSTAN
+        'KH' => ['#####'],                     # CAMBODIA
+        'KI' => [],                            # KIRIBATI
+        'KM' => [],                            # COMOROS
+        'KN' => [],                            # SAINT KITTS AND NEVIS
+        'KO' => [],                            # KOSOVO
+        'KP' => [],                            # NORTH KOREA
+        'KR' => ['###-###', '#####'],          # SOUTH KOREA
+        'KW' => ['#####'],                     # KUWAIT
+        'KY' => ['KY#-####'],                  # CAYMAN ISLANDS
+        'KZ' => ['######'],                    # KAZAKHSTAN
 
-        'LA' => array('#####'),                     # LAO PEOPLE'S DEMOCRATIC REPUBLIC
-        'LB' => array('#####', '#### ####'),        # LEBANON
-        'LC' => array('LC## ###'),                  # SAINT LUCIA
-        'LI' => array('####'),                      # LIECHTENSTEIN
-        'LK' => array('#####'),                     # SRI LANKA
-        'LR' => array('####'),                      # LIBERIA
-        'LS' => array('###'),                       # LESOTHO
-        'LT' => array('LT-#####', '#####'),         # LITHUANIA
-        'LU' => array('####'),                      # LUXEMBOURG
-        'LV' => array('LV-####'),                   # LATVIA
-        'LY' => array(),                            # LIBYAN ARAB JAMAHIRIYA
+        'LA' => ['#####'],                     # LAO PEOPLE'S DEMOCRATIC REPUBLIC
+        'LB' => ['#####', '#### ####'],        # LEBANON
+        'LC' => ['LC## ###'],                  # SAINT LUCIA
+        'LI' => ['####'],                      # LIECHTENSTEIN
+        'LK' => ['#####'],                     # SRI LANKA
+        'LR' => ['####'],                      # LIBERIA
+        'LS' => ['###'],                       # LESOTHO
+        'LT' => ['LT-#####', '#####'],         # LITHUANIA
+        'LU' => ['####'],                      # LUXEMBOURG
+        'LV' => ['LV-####'],                   # LATVIA
+        'LY' => [],                            # LIBYAN ARAB JAMAHIRIYA
 
-        'MA' => array('#####'),                     # MOROCCO
-        'MC' => array('980##'),                     # MONACO
-        'MD' => array('MD####', 'MD-####'),         # MOLDOVA
-        'ME' => array('#####'),                     # MONTENEGRO
-        'MF' => array('97150'),                     # Saint-Martin
-        'MG' => array('###'),                       # MADAGASCAR
-        'MH' => array('#####', '#####-####'),       # MARSHALL ISLANDS
-        'MK' => array('####'),                      # MACEDONIA
-        'ML' => array(),                            # MALI
-        'MM' => array('#####'),                     # MYANMAR
-        'MN' => array('#####'),                     # MONGOLIA
-        'MO' => array(),                            # MACAU
-        'MP' => array('#####', '#####-####'),       # SAIPAN, NORTHERN MARIANA ISLANDS
-        'MQ' => array('972##'),                     # MARTINIQUE
-        'MR' => array(),                            # MAURITANIA
-        'MS' => array(),                            # MONTSERRAT
-        'MT' => array('@@@ ####'),                  # MALTA
-        'MU' => array('#####'),                     # MAURITIUS
-        'MV' => array('#####'),                     # MALDIVES
-        'MW' => array(),                            # MALAWI
-        'MX' => array('#####'),                     # MEXICO
-        'MY' => array('#####'),                     # MALAYSIA
-        'MZ' => array('####'),                      # MOZAMBIQUE
+        'MA' => ['#####'],                     # MOROCCO
+        'MC' => ['980##'],                     # MONACO
+        'MD' => ['MD####', 'MD-####'],         # MOLDOVA
+        'ME' => ['#####'],                     # MONTENEGRO
+        'MF' => ['97150'],                     # SAINT-MARTIN
+        'MG' => ['###'],                       # MADAGASCAR
+        'MH' => ['#####', '#####-####'],       # MARSHALL ISLANDS
+        'MK' => ['####'],                      # MACEDONIA
+        'ML' => [],                            # MALI
+        'MM' => ['#####'],                     # MYANMAR
+        'MN' => ['#####'],                     # MONGOLIA
+        'MO' => [],                            # MACAU
+        'MP' => ['#####', '#####-####'],       # SAIPAN, NORTHERN MARIANA ISLANDS
+        'MQ' => ['972##'],                     # MARTINIQUE
+        'MR' => [],                            # MAURITANIA
+        'MS' => [],                            # MONTSERRAT
+        'MT' => ['@@@ ####'],                  # MALTA
+        'MU' => ['#####'],                     # MAURITIUS
+        'MV' => ['#####'],                     # MALDIVES
+        'MW' => [],                            # MALAWI
+        'MX' => ['#####'],                     # MEXICO
+        'MY' => ['#####'],                     # MALAYSIA
+        'MZ' => ['####'],                      # MOZAMBIQUE
 
-        'NA' => array(),                            # NAMIBIA
-        'NC' => array('988##'),                     # NEW CALEDONIA
-        'NE' => array('####'),                      # NIGER
-        'NF' => array('####'),                      # NORFOLK ISLAND
-        'NG' => array('######'),                    # NIGERIA
-        'NI' => array('#####'),                     # NICARAGUA
-        'NL' => array('####@@', '#### @@'),         # NETHERLANDS
-        'NO' => array('####'),                      # NORWAY
-        'NP' => array('#####'),                     # NEPAL
-        'NR' => array(),                            # NAURU
-        'NU' => array(),                            # NIUE
-        'NZ' => array('####'),                      # NEW ZEALAND
+        'NA' => [],                            # NAMIBIA
+        'NC' => ['988##'],                     # NEW CALEDONIA
+        'NE' => ['####'],                      # NIGER
+        'NF' => ['####'],                      # NORFOLK ISLAND
+        'NG' => ['######'],                    # NIGERIA
+        'NI' => ['#####'],                     # NICARAGUA
+        'NL' => ['####@@', '#### @@'],         # NETHERLANDS
+        'NO' => ['####'],                      # NORWAY
+        'NP' => ['#####'],                     # NEPAL
+        'NR' => [],                            # NAURU
+        'NU' => [],                            # NIUE
+        'NZ' => ['####'],                      # NEW ZEALAND
 
-        'OM' => array('###'),                       # OMAN
+        'OM' => ['###'],                       # OMAN
 
-        'PA' => array('####'),                      # PANAMA
-        'PE' => array('#####', 'PE #####'),         # PERU
-        'PF' => array('987##'),                     # FRENCH POLYNESIA
-        'PG' => array('###'),                       # PAPUA NEW GUINEA
-        'PH' => array('####'),                      # PHILIPPINES
-        'PK' => array('#####'),                     # PAKISTAN
-        'PL' => array('##-###'),                    # POLAND
-        'PM' => array('97500'),                     # ST. PIERRE AND MIQUELON
-        'PN' => array('PCRN 1ZZ'),                  # PITCAIRN
-        'PR' => array('#####', '#####-####'),       # PUERTO RICO
-        'PS' => array('###'),                       # PALESTINIAN TERRITORY
-        'PT' => array('####-###'),                  # PORTUGAL
-        'PW' => array('#####', '#####-####'),       # PALAU
-        'PY' => array('####'),                      # PARAGUAY
+        'PA' => ['####'],                      # PANAMA
+        'PE' => ['#####', 'PE #####'],         # PERU
+        'PF' => ['987##'],                     # FRENCH POLYNESIA
+        'PG' => ['###'],                       # PAPUA NEW GUINEA
+        'PH' => ['####'],                      # PHILIPPINES
+        'PK' => ['#####'],                     # PAKISTAN
+        'PL' => ['##-###'],                    # POLAND
+        'PM' => ['97500'],                     # ST. PIERRE AND MIQUELON
+        'PN' => ['PCRN 1ZZ'],                  # PITCAIRN
+        'PR' => ['#####', '#####-####'],       # PUERTO RICO
+        'PS' => ['###'],                       # PALESTINIAN TERRITORY
+        'PT' => ['####-###'],                  # PORTUGAL
+        'PW' => ['#####', '#####-####'],       # PALAU
+        'PY' => ['####'],                      # PARAGUAY
 
-        'QA' => array(),                            # QATAR
+        'QA' => [],                            # QATAR
 
-        'RE' => array('974##'),                     # REUNION
-        'RO' => array('######'),                    # ROMANIA
-        'RS' => array('#####'),                     # SERBIA
-        'RU' => array('######'),                    # RUSSIA
-        'RW' => array(),                            # RWANDA
+        'RE' => ['974##'],                     # REUNION
+        'RO' => ['######'],                    # ROMANIA
+        'RS' => ['#####'],                     # SERBIA
+        'RU' => ['######'],                    # RUSSIA
+        'RW' => [],                            # RWANDA
 
-        'SA' => array('#####', '#####-####'),       # SAUDI ARABIA
-        'SB' => array(),                            # SOLOMON ISLANDS
-        'SC' => array(),                            # SEYCHELLES
-        'SD' => array('#####'),                     # SUDAN
-        'SE' => array('### ##'),                    # SWEDEN
-        'SG' => array('######'),                    # SINGAPORE
-        'SH' => array('@@@@ 1ZZ'),                  # ST. HELENA
-        'SI' => array('####', 'SI-####'),           # SLOVENIA
-        'SJ' => array('####'),                      # SVALBARD AND JAN MAYEN ISLANDS
-        'SK' => array('### ##'),                    # SLOVAKIA
-        'SL' => array(),                            # SIERRA LEONE
-        'SM' => array('4789#'),                     # SAN MARINO
-        'SN' => array('#####'),                     # SENEGAL
-        'SO' => array('@@ #####'),                  # SOMALIA
-        'SR' => array(),                            # SURINAME
-        'SS' => array('#####'),                     # SOUTH SUDAN
-        'ST' => array(),                            # SAO TOME AND PRINCIPE
-        'SV' => array('####'),                      # EL SALVADOR
-        'SX' => array(),                            # Sint Maarten
-        'SY' => array(),                            # SYRIAN ARAB REPUBLIC
-        'SZ' => array('@###'),                      # SWAZILAND
+        'SA' => ['#####', '#####-####'],       # SAUDI ARABIA
+        'SB' => [],                            # SOLOMON ISLANDS
+        'SC' => [],                            # SEYCHELLES
+        'SD' => ['#####'],                     # SUDAN
+        'SE' => ['### ##'],                    # SWEDEN
+        'SG' => ['######'],                    # SINGAPORE
+        'SH' => ['@@@@ 1ZZ'],                  # ST. HELENA
+        'SI' => ['####', 'SI-####'],           # SLOVENIA
+        'SJ' => ['####'],                      # SVALBARD AND JAN MAYEN ISLANDS
+        'SK' => ['### ##'],                    # SLOVAKIA
+        'SL' => [],                            # SIERRA LEONE
+        'SM' => ['4789#'],                     # SAN MARINO
+        'SN' => ['#####'],                     # SENEGAL
+        'SO' => ['@@ #####'],                  # SOMALIA
+        'SR' => [],                            # SURINAME
+        'SS' => ['#####'],                     # SOUTH SUDAN
+        'ST' => [],                            # SAO TOME AND PRINCIPE
+        'SV' => ['####'],                      # EL SALVADOR
+        'SX' => [],                            # SINT MAARTEN
+        'SY' => [],                            # SYRIAN ARAB REPUBLIC
+        'SZ' => ['@###'],                      # SWAZILAND
 
-        'TA' => array(),                            # Tristan da Cunha
-        'TC' => array('TKCA 1ZZ'),                  # TURKS AND CAICOS ISLANDS
-        'TD' => array(),                            # CHAD
-        'TF' => array(),                            # FRENCH SOUTHERN TERRITORIES
-        'TG' => array(),                            # TOGO
-        'TH' => array('#####'),                     # THAILAND
-        'TJ' => array('######'),                    # TAJIKISTAN
-        'TK' => array(),                            # TOKELAU
-        'TL' => array(),                            # EAST TIMOR
-        'TM' => array('######'),                    # TURKMENISTAN
-        'TN' => array('####'),                      # TUNISIA
-        'TO' => array(),                            # TONGA
-        'TR' => array('#####'),                     # TURKEY
-        'TT' => array('######'),                    # TRINIDAD AND TOBAGO
-        'TV' => array(),                            # TUVALU
-        'TW' => array('###', '###-##'),             # TAIWAN
-        'TZ' => array('#####'),                     # TANZANIA
+        'TA' => [],                            # TRISTAN DA CUNHA
+        'TC' => ['TKCA 1ZZ'],                  # TURKS AND CAICOS ISLANDS
+        'TD' => [],                            # CHAD
+        'TF' => [],                            # FRENCH SOUTHERN TERRITORIES
+        'TG' => [],                            # TOGO
+        'TH' => ['#####'],                     # THAILAND
+        'TJ' => ['######'],                    # TAJIKISTAN
+        'TK' => [],                            # TOKELAU
+        'TL' => [],                            # EAST TIMOR
+        'TM' => ['######'],                    # TURKMENISTAN
+        'TN' => ['####'],                      # TUNISIA
+        'TO' => [],                            # TONGA
+        'TR' => ['#####'],                     # TURKEY
+        'TT' => ['######'],                    # TRINIDAD AND TOBAGO
+        'TV' => [],                            # TUVALU
+        'TW' => ['###', '###-##'],             # TAIWAN
+        'TZ' => ['#####'],                     # TANZANIA
 
-        'UA' => array('#####'),                     # UKRAINE
-        'UG' => array(),                            # UGANDA
-        'UM' => array(),                            # UNITED STATES MINOR OUTLYING ISLANDS
-        'US' => array('#####', '#####-####'),       # USA
-        'UY' => array('#####'),                     # URUGUAY
-        'UZ' => array('######'),                    # USBEKISTAN
+        'UA' => ['#####'],                     # UKRAINE
+        'UG' => [],                            # UGANDA
+        'UM' => [],                            # UNITED STATES MINOR OUTLYING ISLANDS
+        'US' => ['#####', '#####-####'],       # USA
+        'UY' => ['#####'],                     # URUGUAY
+        'UZ' => ['######'],                    # USBEKISTAN
 
-        'VA' => array('00120'),                     # VATICAN CITY STATE
-        'VC' => array('VC####'),                    # SAINT VINCENT AND THE GRENADINES
-        'VE' => array('####', '####-@'),            # VENEZUELA
-        'VG' => array('VG####'),                    # VIRGIN ISLANDS (BRITISH)
-        'VI' => array('#####', '#####-####'),       # VIRGIN ISLANDS (U.S.)
-        'VN' => array('######'),                    # VIETNAM
-        'VU' => array(),                            # VANUATU
+        'VA' => ['00120'],                     # VATICAN CITY STATE
+        'VC' => ['VC####'],                    # SAINT VINCENT AND THE GRENADINES
+        'VE' => ['####', '####-@'],            # VENEZUELA
+        'VG' => ['VG####'],                    # VIRGIN ISLANDS (BRITISH)
+        'VI' => ['#####', '#####-####'],       # VIRGIN ISLANDS (U.S.)
+        'VN' => ['######'],                    # VIETNAM
+        'VU' => [],                            # VANUATU
 
-        'WF' => array('986##'),                     # WALLIS AND FUTUNA ISLANDS
-        'WS' => array('WS####'),                    # SAMOA
+        'WF' => ['986##'],                     # WALLIS AND FUTUNA ISLANDS
+        'WS' => ['WS####'],                    # SAMOA
 
-        'YE' => array(),                            # YEMEN
-        'YT' => array('976##'),                     # MAYOTTE
+        'YE' => [],                            # YEMEN
+        'YT' => ['976##'],                     # MAYOTTE
 
-        'ZA' => array('####'),                      # SOUTH AFRICA
-        'ZM' => array('#####'),                     # ZAMBIA
-        'ZW' => array(),                            # ZIMBABWE
-    );
+        'ZA' => ['####'],                      # SOUTH AFRICA
+        'ZM' => ['#####'],                     # ZAMBIA
+        'ZW' => [],                            # ZIMBABWE
+    ];
 
     /**
      * @param string $countryCode
@@ -313,14 +313,13 @@ class Validator
      * @return bool
      * @throws \Sirprize\PostalCodeValidator\ValidationException
      */
-    public function isValid($countryCode, $postalCode, $ignoreSpaces = false)
+    public function isValid(string $countryCode, string $postalCode, bool $ignoreSpaces = false): bool
     {
         if (!isset($this->formats[$countryCode])) {
             throw new ValidationException(sprintf('Invalid country code: "%s"', $countryCode));
         }
 
         foreach($this->formats[$countryCode] as $format) {
-            #echo $postalCode . ' - ' . $this->getFormatPattern($format)."\n";
             if (preg_match($this->getFormatPattern($format, $ignoreSpaces), $postalCode)) {
                 return true;
             }
@@ -336,10 +335,10 @@ class Validator
     /**
      * @param string $countryCode
      *
-     * @return mixed
+     * @return array
      * @throws \Sirprize\PostalCodeValidator\ValidationException
      */
-    public function getFormats($countryCode)
+    public function getFormats(string $countryCode): array
     {
         if (!isset($this->formats[$countryCode])) {
             throw new ValidationException(sprintf('Invalid country code: "%s"', $countryCode));
@@ -353,9 +352,9 @@ class Validator
      *
      * @return bool
      */
-    public function hasCountry($countryCode)
+    public function hasCountry(string $countryCode): bool
     {
-        return (isset($this->formats[$countryCode]));
+        return isset($this->formats[$countryCode]);
     }
 
     /**
@@ -364,13 +363,13 @@ class Validator
      *
      * @return string
      */
-    protected function getFormatPattern($format, $ignoreSpaces = false)
+    protected function getFormatPattern(string $format, bool $ignoreSpaces = false): string
     {
         $pattern = str_replace('#', '\d', $format);
         $pattern = str_replace('@', '[a-zA-Z]', $pattern);
         $pattern = str_replace('*', '[a-zA-Z0-9]', $pattern);
 
-        if ($ignoreSpaces) {
+        if ($ignoreSpaces === true) {
             $pattern = str_replace(' ', ' ?', $pattern);
         }
 

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -116,11 +116,10 @@ class ValidatorTest extends TestCase
         $this->assertSame(array('###', '###-##'), $validator->getFormats('TW'));
     }
 
-    /**
-     * @expectedException \Sirprize\PostalCodeValidator\ValidationException
-     */
     public function testGetFormatsWithInvalidCountryCode()
     {
+        $this->expectException(ValidationException::class);
+
         $validator = new Validator();
         $validator->getFormats('invalid_postal_code');
     }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -8,19 +8,12 @@
 
 namespace Sirprize\PostalCodeValidator\Tests;
 
+use Sirprize\PostalCodeValidator\ValidationException;
 use Sirprize\PostalCodeValidator\Validator;
 use PHPUnit\Framework\TestCase;
 
 class ValidatorTest extends TestCase
 {
-    /**
-     * @expectedException \Sirprize\PostalCodeValidator\ValidationException
-     */
-    public function testInvalidCountryCode()
-    {
-        $validator = new Validator();
-        $validator->isValid('XXXXXX', 'YYYYYY');
-    }
 
     public function testUkCode()
     {
@@ -104,10 +97,16 @@ class ValidatorTest extends TestCase
         $this->assertTrue($validator->isValid('CZ', '60200', true));
     }
 
-    public function testIrelandCode()
+    /**
+     * @test
+     * @throws ValidationException
+     *
+     * Test if getFormats() works. TW is just an example country code
+     */
+    public function testGetFormats()
     {
         $validator = new Validator();
-        $this->assertTrue($validator->isValid('IE', 'T12 Y03W'));
+        $this->assertSame(array('###', '###-##'), $validator->getFormats('TW'));
     }
 
     public function testGetFormats()

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -14,82 +14,112 @@ use PHPUnit\Framework\TestCase;
 
 class ValidatorTest extends TestCase
 {
-
-    public function testUkCode()
+    public function dataProviderPostalCodes()
     {
-        $validator = new Validator();
-        $this->assertTrue($validator->isValid('GB', 'TN1 2GE'));
-        $this->assertTrue($validator->isValid('GB', 'BD16 3QA'));
+        return [
+            'BE Belgium' => [
+                'country' => 'BE',
+                'valid' => ['3007'],
+                'invalid' => [],
+            ],
+            'CH Switzerland' => [
+                'country' => 'CH',
+                'valid' => ['3007'],
+                'invalid' => [],
+            ],
+            'CZ Czech Republic' => [
+                'country' => 'CZ',
+                'valid' => ['602 00'],
+                'invalid' => ['60200'],
+            ],
+            'DE Germany' => [
+                'country' => 'DE',
+                'valid' => ['50672'],
+                'invalid' => [],
+            ],
+            'EE Estonia' => [
+                'country' => 'EE',
+                'valid' => ['10123'],
+                'invalid' => [],
+            ],
+            'FI inland' => [
+                'country' => 'FI',
+                'valid' => ['00160'],
+                'invalid' => [],
+            ],
+            'GB Great Britain' => [
+                'country' => 'GB',
+                'valid' => ['TN1 2GE', 'BD16 3QA'],
+                'invalid' => [],
+            ],
+            'IE Ireland' => [
+                'country' => 'IE',
+                'valid' => ['T12 Y03W'],
+                'invalid' => [],
+            ],
+            'IT Italy' => [
+                'country' => 'IT',
+                'valid' => ['00146'],
+                'invalid' => [],
+            ],
+            'JP Japan' => [
+                'country' => 'JP',
+                'valid' => ['155-0031'],
+                'invalid' => ['1550031'],
+            ],
+            'NL Netherlands' => [
+                'country' => 'NL',
+                'valid' => ['1234AB', '1234 AB'],
+                'invalid' => ['1234', '1234  AB'],
+            ],
+            'PT Portugal' => [
+                'country' => 'PT',
+                'valid' => ['2765-073'],
+                'invalid' => [],
+            ],
+            'RU Russia' => [
+                'country' => 'RU',
+                'valid' => ['624800'],
+                'invalid' => [],
+            ],
+            'SE Sweden' => [
+                'country' => 'SE',
+                'valid' => ['113 37'],
+                'invalid' => [],
+            ],
+            'US USA' => [
+                'country' => 'US',
+                'valid' => ['81301'],
+                'invalid' => [],
+            ],
+        ];
     }
 
-    public function testSwissCode()
+    /**
+     * @dataProvider dataProviderPostalCodes
+     * @param string $country
+     * @param string[] $validPostalCodes
+     * @param string[] $invalidPostalCodes
+     * @throws ValidationException
+     */
+    public function testValidPostalCodes($country, $validPostalCodes, $invalidPostalCodes)
     {
         $validator = new Validator();
-        $this->assertTrue($validator->isValid('CH', '3007'));
+        foreach ($validPostalCodes as $postalCode) {
+            $this->assertTrue($validator->isValid($country, $postalCode));
+        }
+
+        foreach ($invalidPostalCodes as $postalCode) {
+            $this->assertFalse($validator->isValid($country, $postalCode));
+        }
     }
 
-    public function testGermanCode()
-    {
-        $validator = new Validator();
-        $this->assertTrue($validator->isValid('DE', '50672'));
-    }
-
-    public function testPortugeseCode()
-    {
-        $validator = new Validator();
-        $this->assertTrue($validator->isValid('PT', '2765-073'));
-    }
-
-    public function testJapaneseCode()
-    {
-        $validator = new Validator();
-        $this->assertTrue($validator->isValid('JP', '155-0031'));
-        $this->assertFalse($validator->isValid('JP', '1550031'));
-    }
-
-    public function testUsCode()
-    {
-        $validator = new Validator();
-        $this->assertTrue($validator->isValid('US', '81301'));
-    }
-
-    public function testEstonianCode()
-    {
-        $validator = new Validator();
-        $this->assertTrue($validator->isValid('EE', '10123'));
-    }
-
-    public function testRussianCode()
-    {
-        $validator = new Validator();
-        $this->assertTrue($validator->isValid('RU', '624800'));
-    }
-
-    public function testBelgianCode()
-    {
-        $validator = new Validator();
-        $this->assertTrue($validator->isValid('BE', '1620'));
-    }
-
-    public function testItalianCode()
-    {
-        $validator = new Validator();
-        $this->assertTrue($validator->isValid('IT', '00146'));
-    }
-
-    public function testFinnishCode()
-    {
-        $validator = new Validator();
-        $this->assertTrue($validator->isValid('FI', '00160'));
-    }
-
-    public function testSwedishCode()
-    {
-        $validator = new Validator();
-        $this->assertTrue($validator->isValid('SE', '113 37'));
-    }
-
-    public function testCzechCode()
+    /**
+     * @test
+     *
+     * Test if ignoreSpaces options works. CZ is just an example country code
+     */
+    public function testIgnoreSpaces()
     {
         $validator = new Validator();
         $this->assertTrue($validator->isValid('CZ', '602 00'));
@@ -109,10 +139,12 @@ class ValidatorTest extends TestCase
         $this->assertSame(array('###', '###-##'), $validator->getFormats('TW'));
     }
 
-    public function testGetFormats()
+    public function testInvalidCountryCode()
     {
+        $this->expectException(ValidationException::class);
+
         $validator = new Validator();
-        $this->assertSame(array('###', '###-##'), $validator->getFormats('TW'));
+        $validator->isValid('XXXXXX', 'YYYYYY');
     }
 
     public function testGetFormatsWithInvalidCountryCode()


### PR DESCRIPTION
### Requirements:
- PHP 7.2 (because PHP <7.2 is EOL and should not be used anymore)
- PHPUnit 8

### Added
- Added type hinting
- Added data provider for test to make testing even easier. Would recommend to ask contributors to update this data provider if they add countries or formats.