### PR TITLE
Limit Eircode (IE) routing key so we can exclude Northern Irish postal codes

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -137,7 +137,7 @@ class Validator
 
         'IC' => ['#####'],                     # THE CANARY ISLANDS
         'ID' => ['#####'],                     # INDONESIA
-        'IE' => ['@** ****'],                  # IRELAND
+        'IE' => ['@#* ****'],                  # IRELAND
         'IL' => ['#######'],                   # ISRAEL
         'IM' => ['IM# #@@', 'IM## #@@'],       # Isle of Man
         'IN' => ['######', '### ###'],         # INDIA

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -54,8 +54,8 @@ class ValidatorTest extends TestCase
             ],
             'IE Ireland' => [
                 'country' => 'IE',
-                'valid' => ['T12 Y03W'],
-                'invalid' => [],
+                'valid' => ['T12 Y03W', 'D6W XK06'],
+                'invalid' => ['BT7 90HR'],
             ],
             'IT Italy' => [
                 'country' => 'IT',


### PR DESCRIPTION
On page 11 here it is stated that the routing key should have a digit as the second character, so I have updated the format accordingly: https://www.eircode.ie/docs/default-source/Common/prepareyourbusinessforeircode-edition3published.pdf?sfvrsn=2

Adding this restriction helps to avoid the situations when ignoring spaces where a Northern Irish postcode (e.g BT79 0HR) can correctly validate as IE when it is actually GB. Users can get a bit confused when choosing delivery country, so being able to distinguish is really useful.

I have also added a couple of tests the ensure the above and for a Dublin postcode (D6W XK06) that is in an unusual format (W for last character in routing key).