### PR TITLE
Add optional L- prefix for Luxembourg postcodes.

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -173,7 +173,7 @@ class Validator
         'LR' => ['####'],                      # LIBERIA
         'LS' => ['###'],                       # LESOTHO
         'LT' => ['LT-#####', '#####'],         # LITHUANIA
-        'LU' => ['####'],                      # LUXEMBOURG
+        'LU' => ['L-####', '####'],                      # LUXEMBOURG
         'LV' => ['LV-####'],                   # LATVIA
         'LY' => [],                            # LIBYAN ARAB JAMAHIRIYA
 

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -67,6 +67,11 @@ class ValidatorTest extends TestCase
                 'valid' => ['155-0031'],
                 'invalid' => ['1550031'],
             ],
+            'LU Luxembourg' => [
+                'country' => 'LU',
+                'valid' => ['1099', 'L-1099'],
+                'invalid' => ['123', '12345'],
+            ],
             'NL Netherlands' => [
                 'country' => 'NL',
                 'valid' => ['1234AB', '1234 AB'],


### PR DESCRIPTION
Luxembourg postcodes are sometimes represented with an `L-` prefix. Update the format to support this and add a few unit tests.

See here for confirmation of the use of this format: https://www.angloinfo.com/how-to/luxembourg/housing/postal-system