### PR TITLE
Cambodian ZIP format extended by 6 digit numbers

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -154,7 +154,7 @@ class Validator
 
         'KE' => ['#####'],                     # KENYA
         'KG' => ['######'],                    # KYRGYZSTAN
-        'KH' => ['#####'],                     # CAMBODIA
+        'KH' => ['#####', '######'],           # CAMBODIA
         'KI' => [],                            # KIRIBATI
         'KM' => [],                            # COMOROS
         'KN' => [],                            # SAINT KITTS AND NEVIS


### PR DESCRIPTION
Cambodia has 6 digit zip codes now.

Example address:
https://www.google.com/maps/place/Prasat+Study+Abroad+Consultancy+(PSAC)/@11.6195205,104.8212724,12z/data=!4m10!1m2!2m1!1sPrasat+Study+Abroad+Consultancy!3m6!1s0x31095122679e1a89:0x5304fd5ad1d1cd77!8m2!3d11.5999991!4d104.9244421!15sCh9QcmFzYXQgU3R1ZHkgQWJyb2FkIENvbnN1bHRhbmN5kgEWZWR1Y2F0aW9uYWxfY29uc3VsdGFudOABAA!16s%2Fg%2F11cp5sh6gk

Sources:
https://en.wikipedia.org/wiki/List_of_postal_codes
https://www.tourismcambodia.com/tourist-information/phnom-penh-postal-code.htm