### PR TITLE
Add one more format to the Faroe Islands

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -104,7 +104,7 @@ class Validator
         'FJ' => [],                            # FIJI
         'FK' => ['FIQQ 1ZZ'],                  # FALKLAND ISLANDS (MALVINAS)
         'FM' => ['#####', '#####-####'],       # MICRONESIA
-        'FO' => ['###'],                       # FAROE ISLANDS
+        'FO' => ['###', 'FO-###'],             # FAROE ISLANDS
         'FR' => ['#####'],                     # FRANCE
         'FX' => [],                            # FRANCE, METROPOLITAN
 


### PR DESCRIPTION
As per the Wikipedia [page](https://en.wikipedia.org/wiki/List_of_postal_codes) the library refers to, the Faroe Islands have the format "FO-NNN": "3-digit postal code preceded by FO".